### PR TITLE
Allow broadcast of BT packets with arbitrary data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 BTLE
 ====
 
+This is a fork of floe's BTLE library; it has some improvements to make it able
+to mimick nRF8001 and nRF51822 beacon packets. 
+More info on http://simonebaracchi.eu/posts/temperature-beacon/ .
+
 Arduino library for basic Bluetooth Low Energy support using the nRF24L01+
 (basic support = sending & receiving on the advertising broadcast channel)
 

--- a/examples/temperature/temperature.ino
+++ b/examples/temperature/temperature.ino
@@ -1,0 +1,46 @@
+/*
+ * Emulates a nRF8001 temperature beacon; 
+ * reads temperature from a DHT11 and sends it via BTLE.
+ * Compatible with Nordic Semiconductor apps such as
+ * nRF Master Control Panel or nRF Temp 2.0.
+ */
+
+#include <BTLE.h>
+
+#include <SPI.h>
+#include <RF24.h>
+#include <dht.h>
+
+RF24 radio(9,10);
+BTLE btle(&radio);
+
+dht DHT;
+
+void setup() {
+  Serial.begin(57600);
+  while (!Serial) { }
+  Serial.println("BTLE temperature sender");
+  Serial.end();
+
+  // 8 chars max
+  btle.begin("SimoTemp");
+}
+
+void loop() {
+  DHT.read11(A0);
+
+  nrf_service_data buf;
+  buf.service_uuid = NRF_TEMPERATURE_SERVICE_UUID;
+  buf.value = BTLE::to_nRF_Float(DHT.temperature);
+  
+  if(!btle.advertise(0x16, &buf, sizeof(buf))) {
+    Serial.begin(57600);
+    Serial.println("BTLE advertisement failure");
+    Serial.end();
+  }
+  btle.hopChannel();
+  
+  delay(1000);
+
+}
+


### PR DESCRIPTION
I made a patch to make the library able to send arbitrary data types.
With this patch I was able to mimick the nRF8001 or nRF51822 sending temperature data, and use Nordic Semiconductors Android apps to log it.
Hope you like it!