### PR TITLE
Revert incorrect readme edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 BTLE
 ====
 
-This is a fork of floe's BTLE library; it has some improvements to make it able
-to mimick nRF8001 and nRF51822 beacon packets and to work with maintained RF24.
-More info on http://simonebaracchi.eu/posts/temperature-beacon/ .
-
 Arduino library for basic Bluetooth Low Energy support using the nRF24L01+
 (basic support = sending & receiving on the advertising broadcast channel)
 


### PR DESCRIPTION
This reverts commit 592fcbd8de70c27d65bc21b1791f328fc290dc96.
The edit says:
>This is a fork of floe's BTLE library